### PR TITLE
Derived state strict types

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -4,9 +4,9 @@ use bevy_ecs::{
     prelude::*,
     schedule::{
         apply_state_transition, common_conditions::run_once as run_once_condition,
-        run_enter_schedule, setup_state_transitions_in_world, ComputedStates,
+        run_enter_schedule, setup_state_transitions_in_world, ComputedStates, FreeStateMutation,
         InternedScheduleLabel, IntoSystemConfigs, IntoSystemSetConfigs, ManualStateTransitions,
-        ScheduleBuildSettings, ScheduleLabel, StateTransitionEvent, StateMutation, FreeStateMutation,
+        ScheduleBuildSettings, ScheduleLabel, StateMutation, StateTransitionEvent,
     },
 };
 use bevy_utils::{intern::Interned, thiserror::Error, tracing::debug, HashMap, HashSet};
@@ -365,7 +365,9 @@ impl App {
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by adding the [`apply_state_transition`] system manually.
-    pub fn init_state<S: States + StateMutation<MutationType = FreeStateMutation> + FromWorld>(&mut self) -> &mut Self {
+    pub fn init_state<S: States + StateMutation<MutationType = FreeStateMutation> + FromWorld>(
+        &mut self,
+    ) -> &mut Self {
         if !self.world.contains_resource::<State<S>>() {
             setup_state_transitions_in_world(&mut self.world);
             self.init_resource::<State<S>>()
@@ -403,7 +405,10 @@ impl App {
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by adding the [`apply_state_transition`] system manually.
-    pub fn insert_state<S: States + StateMutation<MutationType = FreeStateMutation>>(&mut self, state: S) -> &mut Self {
+    pub fn insert_state<S: States + StateMutation<MutationType = FreeStateMutation>>(
+        &mut self,
+        state: S,
+    ) -> &mut Self {
         setup_state_transitions_in_world(&mut self.world);
         self.insert_resource(State::new(state))
             .init_resource::<NextState<S>>()
@@ -435,10 +440,12 @@ impl App {
     /// If you would like to control how other systems run based on the current state,
     /// you can emulate this behavior using the [`in_state`] [`Condition`].
     pub fn add_computed_state<S: ComputedStates>(&mut self) -> &mut Self {
-        if !self.world.contains_resource::<Events<StateTransitionEvent<S>>>() {
+        if !self
+            .world
+            .contains_resource::<Events<StateTransitionEvent<S>>>()
+        {
             setup_state_transitions_in_world(&mut self.world);
-            self
-                .add_event::<StateTransitionEvent<S>>();
+            self.add_event::<StateTransitionEvent<S>>();
             let mut schedules = self.world.resource_mut::<Schedules>();
             S::register_state_compute_systems_in_schedule(schedules.as_mut());
         }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
         apply_state_transition, common_conditions::run_once as run_once_condition,
         run_enter_schedule, setup_state_transitions_in_world, ComputedStates,
         InternedScheduleLabel, IntoSystemConfigs, IntoSystemSetConfigs, ManualStateTransitions,
-        ScheduleBuildSettings, ScheduleLabel, StateTransitionEvent, StateMutation, state_mutation_types,
+        ScheduleBuildSettings, ScheduleLabel, StateTransitionEvent, StateMutation, FreeStateMutation,
     },
 };
 use bevy_utils::{intern::Interned, thiserror::Error, tracing::debug, HashMap, HashSet};
@@ -365,7 +365,7 @@ impl App {
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by adding the [`apply_state_transition`] system manually.
-    pub fn init_state<S: States + StateMutation<MutationType = state_mutation_types::Free> + FromWorld>(&mut self) -> &mut Self {
+    pub fn init_state<S: States + StateMutation<MutationType = FreeStateMutation> + FromWorld>(&mut self) -> &mut Self {
         if !self.world.contains_resource::<State<S>>() {
             setup_state_transitions_in_world(&mut self.world);
             self.init_resource::<State<S>>()
@@ -403,7 +403,7 @@ impl App {
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by adding the [`apply_state_transition`] system manually.
-    pub fn insert_state<S: States + StateMutation<MutationType = state_mutation_types::Free>>(&mut self, state: S) -> &mut Self {
+    pub fn insert_state<S: States + StateMutation<MutationType = FreeStateMutation>>(&mut self, state: S) -> &mut Self {
         setup_state_transitions_in_world(&mut self.world);
         self.insert_resource(State::new(state))
             .init_resource::<NextState<S>>()

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -511,7 +511,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }
 
-#[proc_macro_derive(States, attributes(compute))]
+#[proc_macro_derive(States)]
 pub fn derive_states(input: TokenStream) -> TokenStream {
     states::derive_states(input)
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -511,7 +511,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }
 
-#[proc_macro_derive(States)]
+#[proc_macro_derive(States, attributes(compute))]
 pub fn derive_states(input: TokenStream) -> TokenStream {
     states::derive_states(input)
 }

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -21,12 +21,7 @@ pub fn derive_states(input: TokenStream) -> TokenStream {
     let mut state_mutation_trait_path = base_trait_path.clone();
     state_mutation_trait_path
         .segments
-        .push(format_ident!("StateMutation").into());
-
-    let mut state_mutation_type_path = base_trait_path.clone();
-    state_mutation_type_path
-        .segments
-        .push(format_ident!("FreeStateMutation").into());
+        .push(format_ident!("FreelyMutableState").into());
 
     let struct_name = &ast.ident;
 
@@ -34,7 +29,6 @@ pub fn derive_states(input: TokenStream) -> TokenStream {
         impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {}
 
         impl #impl_generics #state_mutation_trait_path for #struct_name #ty_generics #where_clause {
-            type MutationType = #state_mutation_type_path;
         }
     }
     .into()

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -6,21 +6,27 @@ use crate::bevy_ecs_path;
 
 pub fn derive_states(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
-    
+
     let generics = ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let mut base_trait_path = bevy_ecs_path();
-    base_trait_path.segments.push(format_ident!("schedule").into());
+    base_trait_path
+        .segments
+        .push(format_ident!("schedule").into());
 
     let mut trait_path = base_trait_path.clone();
     trait_path.segments.push(format_ident!("States").into());
 
     let mut state_mutation_trait_path = base_trait_path.clone();
-    state_mutation_trait_path.segments.push(format_ident!("StateMutation").into());
+    state_mutation_trait_path
+        .segments
+        .push(format_ident!("StateMutation").into());
 
     let mut state_mutation_type_path = base_trait_path.clone();
-    state_mutation_type_path.segments.push(format_ident!("FreeStateMutation").into());
+    state_mutation_type_path
+        .segments
+        .push(format_ident!("FreeStateMutation").into());
 
     let struct_name = &ast.ident;
 

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -1,21 +1,42 @@
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use syn::{parse_macro_input, DeriveInput};
 
 use crate::bevy_ecs_path;
 
 pub fn derive_states(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
+    
     let generics = ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let mut trait_path = bevy_ecs_path();
-    trait_path.segments.push(format_ident!("schedule").into());
+    let mut base_trait_path = bevy_ecs_path();
+    base_trait_path.segments.push(format_ident!("schedule").into());
+
+    let mut trait_path = base_trait_path.clone();
     trait_path.segments.push(format_ident!("States").into());
+
+    let mut state_mutation_trait_path = base_trait_path.clone();
+    state_mutation_trait_path.segments.push(format_ident!("StateMutation").into());
+
+    let mut state_mutation_type_path = base_trait_path.clone();
+    state_mutation_type_path.segments.push(format_ident!("state_mutation_types").into());
+
+    let is_compute = ast.attrs.iter().find_map(|v| {
+        parse_compute(v.to_token_stream())
+    });
+    let type_name = if is_compute.is_some() { "Computed" } else { "Free" };
+
+    state_mutation_type_path.segments.push(format_ident!("{type_name}").into());
+
     let struct_name = &ast.ident;
 
     quote! {
         impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {}
+
+        impl #impl_generics #state_mutation_trait_path for #struct_name #ty_generics #where_clause {
+            type MutationType = #state_mutation_type_path;
+        }
     }
     .into()
 }

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{format_ident, quote};
 use syn::{parse_macro_input, DeriveInput};
 
 use crate::bevy_ecs_path;
@@ -20,14 +20,7 @@ pub fn derive_states(input: TokenStream) -> TokenStream {
     state_mutation_trait_path.segments.push(format_ident!("StateMutation").into());
 
     let mut state_mutation_type_path = base_trait_path.clone();
-    state_mutation_type_path.segments.push(format_ident!("state_mutation_types").into());
-
-    let is_compute = ast.attrs.iter().find_map(|v| {
-        parse_compute(v.to_token_stream())
-    });
-    let type_name = if is_compute.is_some() { "Computed" } else { "Free" };
-
-    state_mutation_type_path.segments.push(format_ident!("{type_name}").into());
+    state_mutation_type_path.segments.push(format_ident!("FreeStateMutation").into());
 
     let struct_name = &ast.ident;
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -48,13 +48,13 @@ use super::{InternedScheduleLabel, Schedule, Schedules};
 pub trait States: 'static + Send + Sync + Clone + PartialEq + Eq + Hash + Debug {}
 
 /// Type defining the approach used to mutate [`Self`] when it implements [`State`].
-/// 
+///
 /// The type itself is auto-implemented for [`ComputedStates`], and an implementation
 /// is included in the derive for [`States`] as well. However - if you are manually
 /// implementing [`States`], you will need to add an implementation yourself.
 pub trait StateMutation: States {
     /// The manner in which we can mutate [`Self`]
-    /// 
+    ///
     /// There are 2 built in approaches:
     /// - [`Free`](`state_mutation_types::Free`) mutation enables the use of the `NextState<Self>`
     ///   resource to mutate the state.
@@ -64,7 +64,7 @@ pub trait StateMutation: States {
 }
 
 /// A trait defining the available approaches for modifying [`States`].
-/// 
+///
 /// The trait is sealed.
 pub trait StateMutationType: sealed::StateMutationTypeSealed {}
 
@@ -389,7 +389,9 @@ pub fn setup_state_transitions_in_world(world: &mut World) {
 /// - Runs the [`OnTransition { from: exited_state, to: entered_state }`](OnTransition), if it exists.
 /// - Derive any dependant states through the [`ComputeDependantStates::<S>`] schedule, if it exists.
 /// - Runs the [`OnEnter(entered_state)`] schedule, if it exists.
-pub fn apply_state_transition<S: StateMutation<MutationType = FreeStateMutation>>(world: &mut World) {
+pub fn apply_state_transition<S: StateMutation<MutationType = FreeStateMutation>>(
+    world: &mut World,
+) {
     // We want to take the `NextState` resource,
     // but only mark it as changed if it wasn't empty.
     let Some(next_state_resource) = world.get_resource::<NextState<S>>() else {

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -48,7 +48,7 @@ use super::{InternedScheduleLabel, Schedule, Schedules};
 pub trait States: 'static + Send + Sync + Clone + PartialEq + Eq + Hash + Debug {}
 
 /// This trait allows a state to be mutated directly using the [`NextState<S>`] resource.
-/// 
+///
 /// It is implemented as part of the [`States`] derive, but can also be added manually.
 pub trait FreelyMutableState: States {}
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -56,9 +56,9 @@ pub trait StateMutation: States {
     /// The manner in which we can mutate [`Self`]
     ///
     /// There are 2 built in approaches:
-    /// - [`Free`](`state_mutation_types::Free`) mutation enables the use of the `NextState<Self>`
+    /// - [`Free`](`FreeStateMutation`) mutation enables the use of the `NextState<Self>`
     ///   resource to mutate the state.
-    /// - [`Computed`](`state_mutation_types::Computed`) mutation relies on automatic computation
+    /// - [`Computed`](`ComputedStateMutation`) mutation relies on automatic computation
     ///   of the state, based on other states in the world.
     type MutationType: StateMutationType;
 }
@@ -451,7 +451,7 @@ mod sealed {
     /// Sealed trait used to prevent external implementations of [`StateSet`](super::StateSet).
     pub trait StateSetSealed {}
 
-    /// Sealed trait used to prevent external implementations of [`StateMutationTypes`](super::StateMutationTypes).
+    /// Sealed trait used to prevent external implementations of [`StateMutationType`](super::StateMutationType).
     pub trait StateMutationTypeSealed {}
 }
 

--- a/examples/ecs/computed_states.rs
+++ b/examples/ecs/computed_states.rs
@@ -39,7 +39,7 @@ enum TutorialState {
 // a separate "InGame" type and implement `ComputedStates` for it.
 // This allows us to only need to check against one type
 // when otherwise we'd need to check against multiple.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, States)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 struct InGame;
 
 impl ComputedStates for InGame {
@@ -70,7 +70,7 @@ impl ComputedStates for InGame {
 // if you aren't in game, for example - while still having the
 // flexibility to check for the states as if they were completely unrelated.
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, States)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 struct TurboMode;
 
 impl ComputedStates for TurboMode {
@@ -96,7 +96,7 @@ impl ComputedStates for TurboMode {
 // - it doesn't exist - this is when being paused is meaningless, like in the menu.
 // - it is `NotPaused` - in which elements like the movement system are active.
 // - it is `Paused` - in which those game systems are inactive, and a pause screen is shown.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, States)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 enum IsPaused {
     NotPaused,
     Paused,
@@ -123,7 +123,7 @@ impl ComputedStates for IsPaused {
 // Like `IsPaused`, the tutorial has a few fully distinct possible states, so we want to represent them
 // as an Enum. However - in this case they are all dependant on multiple states: the root [`TutorialState`],
 // and both [`InGame`] and [`IsPaused`] - which are in turn derived from [`AppState`].
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, States)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 enum Tutorial {
     MovementInstructions,
     PauseInstructions,


### PR DESCRIPTION
This is an experiment illustrating some stricter typing for handling States mutation well.

It introduces a `FreelyMutableState` trait that is implemented by the `States` derive, but not by `ComputedStates`, and relies on it as a basis for `NextState` and the `init_state`/`insert_state` resources.

Otherwise - it doesn't have any other differences.