### PR TITLE
Computed and substate robust macro

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -514,12 +514,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }
 
-#[proc_macro_derive(States)]
+#[proc_macro_derive(States, attributes(substate, computed))]
 pub fn derive_states(input: TokenStream) -> TokenStream {
     states::derive_states(input)
-}
-
-#[proc_macro_derive(SubStates, attributes(source))]
-pub fn derive_substates(input: TokenStream) -> TokenStream {
-    states::derive_substates(input)
 }

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -6,8 +6,8 @@ use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::{
     parse::Parser, parse_macro_input, punctuated::Punctuated, spanned::Spanned, token::Comma,
-    Attribute, DeriveInput, Expr, ExprClosure, Ident, ImplGenerics, Path, Result,
-    TypeGenerics, WhereClause,
+    Attribute, DeriveInput, Expr, ExprClosure, Ident, ImplGenerics, Path, Result, TypeGenerics,
+    WhereClause,
 };
 
 use crate::bevy_ecs_path;

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -1,11 +1,20 @@
+#![allow(clippy::too_many_arguments)]
+use std::fmt::Display;
+
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, spanned::Spanned, DeriveInput, Expr, Path, Result};
+use syn::{
+    parse::Parser, parse_macro_input, punctuated::Punctuated, spanned::Spanned, token::Comma,
+    Attribute, DeriveInput, Expr, ExprClosure, Ident, ImplGenerics, Path, Result,
+    TypeGenerics, WhereClause,
+};
 
 use crate::bevy_ecs_path;
 
 pub fn derive_states(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
+    let sources = parse_state_type(&ast).expect("Failed to parse substate sources");
 
     let generics = ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
@@ -15,109 +24,202 @@ pub fn derive_states(input: TokenStream) -> TokenStream {
         .segments
         .push(format_ident!("schedule").into());
 
+    let struct_name = &ast.ident;
+
+    let mut sections: Vec<proc_macro2::TokenStream> = vec![];
+
+    match sources {
+        StateType::Normal => {
+            sections.push(simple_states(
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+            sections.push(freely_mutable(
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+        }
+        StateType::SubStateSource {
+            source_type,
+            source_value,
+        } => {
+            sections.push(freely_mutable(
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+            sections.push(state_with_dependencies(
+                format_ident!("SubStates"),
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+            sections.push(substates_with_single_type(
+                source_type,
+                source_value,
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+        }
+        StateType::SubStateFunction {
+            types,
+            function_body,
+        } => {
+            sections.push(freely_mutable(
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+            sections.push(state_with_dependencies(
+                format_ident!("SubStates"),
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+            sections.push(state_with_computation(
+                format_ident!("SubStates"),
+                &types,
+                format_ident!("exists"),
+                function_body,
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+        }
+        StateType::ComputedFunction {
+            types,
+            function_body,
+        } => {
+            sections.push(state_with_computation(
+                format_ident!("ComputedStates"),
+                &types,
+                format_ident!("compute"),
+                function_body,
+                &impl_generics,
+                &ty_generics,
+                &where_clause,
+                struct_name,
+                &base_trait_path,
+            ));
+        }
+    }
+
+    proc_macro2::TokenStream::from_iter(sections).into()
+}
+
+fn freely_mutable(
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    struct_name: &Ident,
+    base_trait_path: &Path,
+) -> proc_macro2::TokenStream {
+    let mut trait_path = base_trait_path.clone();
+    trait_path
+        .segments
+        .push(format_ident!("FreelyMutableState").into());
+
+    quote!(
+        impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {}
+    )
+}
+
+fn simple_states(
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    struct_name: &Ident,
+    base_trait_path: &Path,
+) -> proc_macro2::TokenStream {
     let mut trait_path = base_trait_path.clone();
     trait_path.segments.push(format_ident!("States").into());
 
-    let mut state_mutation_trait_path = base_trait_path.clone();
-    state_mutation_trait_path
-        .segments
-        .push(format_ident!("FreelyMutableState").into());
-
-    let struct_name = &ast.ident;
-
     quote! {
         impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {}
+    }
+}
 
-        impl #impl_generics #state_mutation_trait_path for #struct_name #ty_generics #where_clause {
+fn state_with_dependencies(
+    dep_trait: Ident,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    struct_name: &Ident,
+    base_trait_path: &Path,
+) -> proc_macro2::TokenStream {
+    let mut trait_path = base_trait_path.clone();
+    trait_path.segments.push(format_ident!("States").into());
+
+    let mut dep_trait_path = base_trait_path.clone();
+    dep_trait_path.segments.push(dep_trait.into());
+
+    quote! {
+        impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {
+            const DEPENDENCY_DEPTH : usize = <Self as #dep_trait_path>::SourceStates::SET_DEPENDENCY_DEPTH + 1;
         }
     }
-    .into()
 }
 
-struct Source {
-    source_type: Path,
-    source_value: Expr,
-}
+fn state_with_computation(
+    dep_trait: Ident,
+    dep_types: &Expr,
+    computation_name: Ident,
+    computation_body: ExprClosure,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    struct_name: &Ident,
+    base_trait_path: &Path,
+) -> proc_macro2::TokenStream {
+    let mut trait_path = base_trait_path.clone();
+    trait_path.segments.push(dep_trait.into());
 
-fn parse_sources_attr(ast: &DeriveInput) -> Result<Source> {
-    let mut result = ast
-        .attrs
-        .iter()
-        .filter(|a| a.path().is_ident("source"))
-        .map(|meta| {
-            let mut source = None;
-            let value = meta.parse_nested_meta(|nested| {
-                let source_type = nested.path.clone();
-                let source_value = nested.value()?.parse::<Expr>()?;
-                source = Some(Source {
-                    source_type,
-                    source_value,
-                });
-                Ok(())
-            });
-            match source {
-                Some(value) => Ok(value),
-                None => match value {
-                    Ok(_) => Err(syn::Error::new(
-                        ast.span(),
-                        "Couldn't parse SubStates source",
-                    )),
-                    Err(e) => Err(e),
-                },
+    let arguments = computation_body.inputs;
+    let body = computation_body.body;
+
+    quote! {
+        impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {
+            type SourceStates = #dep_types;
+
+            fn #computation_name(#arguments: <<Self as #trait_path>::SourceStates as StateSet>::OptionalStateSet) -> Option<Self> {
+                #body
             }
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    if result.len() > 1 {
-        return Err(syn::Error::new(
-            ast.span(),
-            "Only one source is allowed for SubStates",
-        ));
+        }
     }
-
-    let Some(result) = result.pop() else {
-        return Err(syn::Error::new(ast.span(), "SubStates require a source"));
-    };
-
-    Ok(result)
 }
 
-pub fn derive_substates(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-    let sources = parse_sources_attr(&ast).expect("Failed to parse substate sources");
-
-    let generics = ast.generics;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    let mut base_trait_path = bevy_ecs_path();
-    base_trait_path
-        .segments
-        .push(format_ident!("schedule").into());
-
+fn substates_with_single_type(
+    source_state_type: Path,
+    source_state_value: Expr,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    struct_name: &Ident,
+    base_trait_path: &Path,
+) -> proc_macro2::TokenStream {
     let mut trait_path = base_trait_path.clone();
     trait_path.segments.push(format_ident!("SubStates").into());
 
-    let mut state_set_trait_path = base_trait_path.clone();
-    state_set_trait_path
-        .segments
-        .push(format_ident!("StateSet").into());
-
-    let mut state_trait_path = base_trait_path.clone();
-    state_trait_path
-        .segments
-        .push(format_ident!("States").into());
-
-    let mut state_mutation_trait_path = base_trait_path.clone();
-    state_mutation_trait_path
-        .segments
-        .push(format_ident!("FreelyMutableState").into());
-
-    let struct_name = &ast.ident;
-
-    let source_state_type = sources.source_type;
-    let source_state_value = sources.source_value;
-
-    let result = quote! {
+    quote! {
         impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {
             type SourceStates = #source_state_type;
 
@@ -129,16 +231,160 @@ pub fn derive_substates(input: TokenStream) -> TokenStream {
                 }
             }
         }
+    }
+}
 
-        impl #impl_generics #state_trait_path for #struct_name #ty_generics #where_clause {
-            const DEPENDENCY_DEPTH : usize = <Self as #trait_path>::SourceStates::SET_DEPENDENCY_DEPTH + 1;
-        }
+#[derive(Clone)]
+enum StateType {
+    Normal,
+    SubStateSource {
+        source_type: Path,
+        source_value: Expr,
+    },
+    SubStateFunction {
+        types: Expr,
+        function_body: ExprClosure,
+    },
+    ComputedFunction {
+        types: Expr,
+        function_body: ExprClosure,
+    },
+}
 
-        impl #impl_generics #state_mutation_trait_path for #struct_name #ty_generics #where_clause {
-        }
-    };
+fn parse_state_type(ast: &DeriveInput) -> Result<StateType> {
+    let attrs = &ast.attrs;
+    let span = ast.span();
 
-    // panic!("Got Result\n{}", result.to_string());
+    if let Some(source) = parse_source_attr(attrs, span)? {
+        return Ok(source);
+    }
 
-    result.into()
+    if let Some(functional) = parse_computation_attr(attrs, span)? {
+        return Ok(functional);
+    }
+
+    Ok(StateType::Normal)
+}
+
+fn parse_source_attr(attrs: &[Attribute], span: Span) -> Result<Option<StateType>> {
+    let result = attrs
+        .iter()
+        .filter(|a| a.path().is_ident("substate"))
+        .filter_map(|meta| {
+            let mut source = None;
+            let value = meta.parse_nested_meta(|nested| {
+                let source_type = nested.path.clone();
+                let source_value = nested.value()?.parse::<Expr>()?;
+                source = Some(StateType::SubStateSource {
+                    source_type,
+                    source_value,
+                });
+                Ok(())
+            });
+            match source {
+                Some(value) => Some(Ok(value)),
+                None => match value {
+                    Ok(_) => Some(Err(syn::Error::new(
+                        span,
+                        "Couldn't parse SubStates source",
+                    ))),
+                    Err(_e) => None,
+                },
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if result.len() > 1 {
+        return Err(syn::Error::new(
+            span,
+            "Only one source is allowed for SubStates",
+        ));
+    }
+
+    Ok(result.first().cloned())
+}
+
+#[derive(Debug)]
+enum ComputationTypes {
+    SubState,
+    ComputedState,
+}
+
+impl Display for ComputationTypes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ComputationTypes::SubState => "SubStates",
+            ComputationTypes::ComputedState => "ComputedStates",
+        })
+    }
+}
+
+fn parse_computation_attr(attrs: &[Attribute], span: Span) -> Result<Option<StateType>> {
+    let result = attrs
+        .iter()
+        .filter_map(|a| match &a.meta {
+            syn::Meta::List(list) => {
+                let path = &list.path;
+
+                if path.is_ident("substate") {
+                    Some((ComputationTypes::SubState, list))
+                } else if path.is_ident("computed") {
+                    Some((ComputationTypes::ComputedState, list))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .map(|(computation_type, meta)| {
+            let parser = Punctuated::<Expr, Comma>::parse_separated_nonempty;
+            let content = match parser.parse2(meta.tokens.clone()) {
+                Ok(content) => content,
+                Err(e) => {
+                    return Err(e);
+                }
+            };
+
+            let mut iterator = content.iter();
+            let types = match iterator.next() {
+                Some(types) => types.clone(),
+                None => {
+                    return Err(syn::Error::new(
+                        span,
+                        format!("no types provided for deriving {computation_type}"),
+                    ));
+                }
+            };
+
+            let function_body = match iterator.next() {
+                Some(Expr::Closure(function_body)) => function_body.clone(),
+                _ => {
+                    return Err(syn::Error::new(
+                        span,
+                        format!("no closure provided for deriving {computation_type}"),
+                    ));
+                }
+            };
+
+            Ok(match computation_type {
+                ComputationTypes::SubState => StateType::SubStateFunction {
+                    types,
+                    function_body,
+                },
+                ComputationTypes::ComputedState => StateType::ComputedFunction {
+                    types,
+                    function_body,
+                },
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if result.len() > 1 {
+        return Err(syn::Error::new(
+            span,
+            "Can't define multiple computations on a single state type",
+        ));
+    }
+
+    Ok(result.first().cloned())
 }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -13,7 +13,7 @@ use crate::schedule::ScheduleLabel;
 use crate::system::Resource;
 use crate::world::World;
 
-pub use bevy_ecs_macros::{States, SubStates};
+pub use bevy_ecs_macros::States;
 use bevy_utils::{all_tuples, HashSet};
 
 use self::sealed::StateSetSealed;
@@ -941,8 +941,6 @@ all_tuples!(impl_state_set_sealed_tuples, 1, 15, S, s);
 
 #[cfg(test)]
 mod tests {
-    use bevy_ecs_macros::SubStates;
-
     use super::*;
     use crate as bevy_ecs;
 
@@ -1018,8 +1016,8 @@ mod tests {
         assert!(!world.contains_resource::<State<TestComputedState>>());
     }
 
-    #[derive(SubStates, PartialEq, Eq, Debug, Default, Hash, Clone)]
-    #[source(SimpleState = SimpleState::B(true))]
+    #[derive(States, PartialEq, Eq, Debug, Default, Hash, Clone)]
+    #[substate(SimpleState = SimpleState::B(true))]
     enum SubState {
         #[default]
         One,
@@ -1075,8 +1073,8 @@ mod tests {
         assert!(!world.contains_resource::<State<SubState>>());
     }
 
-    #[derive(SubStates, PartialEq, Eq, Debug, Default, Hash, Clone)]
-    #[source(TestComputedState = TestComputedState::BisTrue)]
+    #[derive(States, PartialEq, Eq, Debug, Default, Hash, Clone)]
+    #[substate(TestComputedState = TestComputedState::BisTrue)]
     enum SubStateOfComputed {
         #[default]
         One,

--- a/examples/ecs/sub_states.rs
+++ b/examples/ecs/sub_states.rs
@@ -17,12 +17,12 @@ enum AppState {
 }
 
 // In this case, instead of deriving `States`, we derive `SubStates`
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, SubStates)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States)]
 // And we need to add an attribute to let us know what the source state is
 // and what value it needs to have. This will ensure that unless we're
 // in [`AppState::InGame`], the [`IsPaused`] state resource
 // will not exist.
-#[source(AppState = AppState::InGame)]
+#[substate(AppState = AppState::InGame)]
 enum IsPaused {
     #[default]
     Running,
@@ -120,21 +120,21 @@ fn setup_menu(mut commands: Commands) {
 fn menu(
     mut next_state: ResMut<NextState<AppState>>,
     mut interaction_query: Query<
-        (&Interaction, &mut BackgroundColor),
+        (&Interaction, &mut UiImage),
         (Changed<Interaction>, With<Button>),
     >,
 ) {
-    for (interaction, mut color) in &mut interaction_query {
+    for (interaction, mut image) in &mut interaction_query {
         match *interaction {
             Interaction::Pressed => {
-                *color = PRESSED_BUTTON.into();
+                image.color = PRESSED_BUTTON;
                 next_state.set(AppState::InGame);
             }
             Interaction::Hovered => {
-                *color = HOVERED_BUTTON.into();
+                image.color = HOVERED_BUTTON;
             }
             Interaction::None => {
-                *color = NORMAL_BUTTON.into();
+                image.color = NORMAL_BUTTON;
             }
         }
     }


### PR DESCRIPTION
# Objective

Simplify the UX of the computed state PR

## Solution

Modify the derive macro for States to allow it to be used to create all 3 state types:
- If no attributes are present, it is a normal state
- If a #[substate(ParentTypes, |parent|  ->Option<Self>)] or #[substate(ParentType = ParentType::Value)] attribute is present, it is a sub state
- If a #[comptued(ParentTypes, |parent|  ->Option<Self>.)] attribute is present, it is a computed state

When using closures, the types can be single types or tuple - whereas using just a type with an "=" for substates relies on a single type only.